### PR TITLE
RAF-800: pom/xml corrected to allow build on any setup without changi…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,18 +75,14 @@
   </properties>
 
   <distributionManagement>
-    <repository>
-      <id>sonatype.release</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
-    </repository>
-    <snapshotRepository>
-      <id>sonatype.snapshots</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <site>
-      <id>cask</id>
-      <url>http://cask.co</url>
-    </site>
+     <repository>
+       <id>central</id>
+       <url>http://artifacts.ggn.in.guavus.com:80/libs-release-local</url>
+     </repository>
+     <snapshotRepository>
+       <id>snapshots</id>
+       <url>http://artifacts.ggn.in.guavus.com:8081/artifactory/libs-snapshot-local</url>
+     </snapshotRepository>
   </distributionManagement>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,10 @@
       <id>sonatype.snapshots</id>
       <url>https://oss.sonatype.org/content/repositories/snapshots</url>
     </snapshotRepository>
+    <site>
+      <id>cask</id>
+      <url>http://cask.co</url>
+    </site>
   </distributionManagement>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -75,15 +75,30 @@
   </properties>
 
   <distributionManagement>
-           <repository>
-               <id>central</id>
-               <url>http://artifacts.ggn.in.guavus.com:80/libs-release-local</url>
-           </repository>
-           <snapshotRepository>
-               <id>snapshots</id>
-               <url>http://artifacts.ggn.in.guavus.com:8081/artifactory/libs-snapshot-local</url>
-           </snapshotRepository>
+    <repository>
+      <id>sonatype.release</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+    </repository>
+    <snapshotRepository>
+      <id>sonatype.snapshots</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
   </distributionManagement>
+
+  <repositories>
+    <repository>
+      <id>guavus.release</id>
+      <url>http://artifacts.ggn.in.guavus.com:80/libs-release-local</url>
+    </repository>
+    <repository>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/groups/public</url>
+    </repository>
+    <repository>
+      <id>sonatype-snapshots</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </repository>
+  </repositories>
 
   <build>
     <pluginManagement>


### PR DESCRIPTION
On a new machine which has default maven settings.xml, compilation of repos fails :

`https://github.com/Guavus/mmds - branch master`

The reason being incorrect reference of <repositories> in poms.

Ideally, the build should be successful on setups with default maven’s settings.xml so that any project cloning and compilation is independent of any other external configs/settings. 

